### PR TITLE
fix: prevent stdout pipe deadlock on Windows

### DIFF
--- a/Hosting.Catalyst/Cli/Commands.cs
+++ b/Hosting.Catalyst/Cli/Commands.cs
@@ -352,10 +352,15 @@ internal static class Commands
             throw new InvalidOperationException("Failed to start diagrid process");
         }
 
+        // Start reading stdout/stderr before waiting for exit to avoid
+        // deadlock when the pipe buffer fills (especially on Windows).
+        var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
         await process.WaitForExitAsync(cancellationToken);
 
-        var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-        var error = await process.StandardError.ReadToEndAsync(cancellationToken);
+        var output = await outputTask;
+        var error = await errorTask;
 
         return (output, error, process.ExitCode);
     }


### PR DESCRIPTION
Start reading stdout/stderr concurrently with `WaitForExitAsync()` to prevent a deadlock when the CLI output exceeds the Windows pipe buffer (4KB). Previously, the process would block on write while Aspire waited for exit, causing all resources to hang in "starting" indefinitely.

ref: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput?view=net-10.0#remarks